### PR TITLE
Implement JWT authentication

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,6 +33,7 @@ validator = { version = "0.18", features = ["derive"] }
 once_cell = "1.19.0"
 tower_governor = "0.7.0" # Updated to version from docs
 hyper = {version = "1.6.0", features = ["full"]}
+jsonwebtoken = "9"
 [dev-dependencies]
 tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
 reqwest = { version = "0.12.20", features = ["json"] } # Assuming this version is fine, not specified in requirements

--- a/config/default.toml
+++ b/config/default.toml
@@ -14,6 +14,9 @@ otel_exporter_otlp_endpoint = "http://localhost:4317"
 rate_limit_per_second = 1
 rate_limit_burst_size = 50
 
+# Secret used for signing JWT tokens
+jwt_secret = "change-me"
+
 # HTTP Headers
 # You can define a list of HTTP headers to be added to every response.
 # These are applied if the header is not already present in the response.

--- a/src/app.rs
+++ b/src/app.rs
@@ -65,24 +65,7 @@ impl Application {
             .layer(GovernorLayer {
                 config: governor_config,
             })
-            // Add our new auth_middleware
-            // Note: The auth_middleware needs to be adapted if it doesn't match `from_fn`'s expected signature directly.
-            // Our current auth_middleware expects HeaderMap, Request, Next.
-            // `from_fn` expects a function that takes Request, Next.
-            // We'll need a wrapper or to adjust auth_middleware.
-            // For now, let's assume a wrapper `auth_middleware_wrapper` similar to tests or adjust it.
-            // Let's create a simple inline wrapper for now, or adjust auth_middleware to fit.
-            // Simpler: adjust auth_middleware or use from_fn_with_state if state is needed early.
-            // Given auth_middleware's current signature: `async fn auth_middleware(headers: HeaderMap, request: Request, next: Next)`
-            // it's not directly compatible with `middleware::from_fn`.
-            // Let's use `middleware::from_fn_with_state` if we needed AppState in middleware,
-            // or a simple wrapper.
-            // The simplest way is to modify auth_middleware to take `Request, Next` and extract headers inside.
-            // Let's go back and modify `auth.rs` for this.
-            // For now, I will add it assuming it's compatible or will be made compatible.
-            // This highlights a potential refinement for auth.rs or the need for a wrapper here.
-            // Let's assume we will adjust auth_middleware to be: `async fn auth_middleware(request: Request, next: Next)`
-            .layer(middleware::from_fn(auth_middleware)); // This now expects auth_middleware to have the compatible signature
+            .layer(middleware::from_fn_with_state(app_state.clone(), auth_middleware));
 
         let untracked_routes = Router::new().route("/metrics", get(handlers::metrics_handler));
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -38,6 +38,9 @@ pub struct Config {
     pub rate_limit_burst_size: u32,
 
     pub http_headers: Option<Vec<HttpHeader>>,
+
+    #[validate(length(min = 1))]
+    pub jwt_secret: String,
 }
 
 impl Config {

--- a/src/infrastructure/web/middleware/auth.rs
+++ b/src/infrastructure/web/middleware/auth.rs
@@ -1,93 +1,57 @@
 use axum::{
-    extract::Request,
-    http::StatusCode, // HeaderMap import removed
+    extract::{Request, State},
+    http::StatusCode,
     middleware::Next,
     response::Response,
 };
-use tracing::info;
+use jsonwebtoken::{decode, DecodingKey, Validation};
+use serde::Deserialize;
+use tracing::{info, warn};
 
-// TODO: Consider moving secrets like JWT_SECRET to a configuration file or environment variables
-// and load them into an application state or a dedicated configuration struct.
-// const JWT_SECRET: &str = "your-secret-jwt-token"; // Example secret, DO NOT use in production
+use crate::app::AppState;
 
-/// Middleware for authenticating requests.
-///
-/// This middleware currently logs the Authorization header if present.
-/// It's a placeholder for actual JWT Bearer token validation.
+#[derive(Debug, Deserialize)]
+struct Claims {
+    sub: String,
+    exp: usize,
+}
+
+/// Middleware for authenticating requests using JWT.
 pub async fn auth_middleware(
-    // headers: HeaderMap, // Headers will be extracted from the request
-    request: Request, // Removed mut from request
+    State(app_state): State<AppState>,
+    mut request: Request,
     next: Next,
 ) -> Result<Response, StatusCode> {
     info!("Entering auth_middleware");
 
-    // Extract headers from the request
-    let headers = request.headers();
-    let auth_header = headers
+    let auth_header = request
+        .headers()
         .get(axum::http::header::AUTHORIZATION)
-        .and_then(|header| header.to_str().ok());
+        .and_then(|h| h.to_str().ok());
 
-    match auth_header {
-        Some(header_value) => {
-            info!("Authorization header found: {}", header_value);
-            // TODO: Implement actual Bearer JWT validation here.
-            // 1. Check if the header starts with "Bearer ".
-            // 2. Parse the token.
-            // 3. Validate the token (signature, expiration, claims).
-            //    - The JWT secret should be loaded from configuration/app state.
-            //    - Example:
-            //      ```
-            //      use jsonwebtoken::{decode, DecodingKey, Validation};
-            //      use crate::AppState; // Assuming you have an AppState
-            //      use axum::extract::State;
-            //
-            //      let app_state = request.extensions().get::<State<AppState>>()
-            //          .expect("AppState not found in request extensions");
-            //      let secret = &app_state.jwt_secret; // Or however you store your secret
-            //
-            //      if let Some(token) = header_value.strip_prefix("Bearer ") {
-            //          let decoding_key = DecodingKey::from_secret(secret.as_ref());
-            //          let validation = Validation::default(); // Customize as needed
-            //          match decode::<Claims>(token, &decoding_key, &validation) {
-            //              Ok(token_data) => {
-            //                  info!("Token validated successfully for user: {:?}", token_data.claims.sub);
-            //                  // You might want to add user information to request extensions
-            //                  // request.extensions_mut().insert(token_data.claims);
-            //              }
-            //              Err(e) => {
-            //                  info!("JWT validation error: {:?}", e);
-            //                  // return Err(StatusCode::UNAUTHORIZED); // Or appropriate error response
-            //              }
-            //          }
-            //      } else {
-            //          info!("Authorization header is not a Bearer token");
-            //          // return Err(StatusCode::UNAUTHORIZED);
-            //      }
-            //      ```
-            // For now, we just log and pass through.
-        }
+    let token = match auth_header.and_then(|h| h.strip_prefix("Bearer ")) {
+        Some(t) => t,
         None => {
-            info!("No Authorization header found in the request.");
-            // Depending on the routes, you might want to deny access if no token is present.
-            // For some public routes, this might be acceptable.
-            // return Err(StatusCode::UNAUTHORIZED);
+            warn!("Missing or malformed Authorization header");
+            return Err(StatusCode::UNAUTHORIZED);
+        }
+    };
+
+    let secret = app_state.config.jwt_secret.as_bytes();
+    match decode::<Claims>(token, &DecodingKey::from_secret(secret), &Validation::default()) {
+        Ok(token_data) => {
+            request.extensions_mut().insert(token_data.claims);
+            let response = next.run(request).await;
+            info!("Exiting auth_middleware");
+            Ok(response)
+        }
+        Err(err) => {
+            warn!(?err, "JWT validation error");
+            Err(StatusCode::UNAUTHORIZED)
         }
     }
-
-    // Proceed to the next middleware or handler
-    let response = next.run(request).await;
-    info!("Exiting auth_middleware");
-    Ok(response)
 }
 
-// Example Claims structure for JWT - define your own as needed
-// use serde::{Deserialize, Serialize};
-// #[derive(Debug, Serialize, Deserialize)]
-// struct Claims {
-//    sub: String, // Subject (usually user ID)
-//    exp: usize,  // Expiration time
-//    // ... other claims
-// }
 
 #[cfg(test)]
 mod tests {
@@ -98,8 +62,6 @@ mod tests {
         Router,
     };
     use tower::ServiceExt; // for `oneshot`
-    // HeaderMap is no longer directly used by auth_middleware's signature in tests, but tests might still construct headers.
-    // axum::http::header is used for request construction.
     use axum::http::header;
 
 
@@ -107,27 +69,31 @@ mod tests {
         "Hello, world!"
     }
 
-    // Test setup: The wrapper must now match the signature that from_fn expects for auth_middleware
-    // auth_middleware expects (Request, Next)
-    // So, the wrapper itself is auth_middleware if no state is needed, or a wrapper that passes state.
-    // from_fn(auth_middleware) is the direct way if auth_middleware matches.
-    // The tests were using a wrapper to extract HeaderMap, which is what auth_middleware did internally.
-    // Now that auth_middleware extracts headers from Request, the tests can call it directly via from_fn.
 
     fn app_with_middleware() -> Router {
+        use crate::{app::AppState, config::Config};
+        use std::sync::Arc;
+
+        let app_state = AppState {
+            config: Arc::new(Config {
+                port: 0,
+                log_level: "info".into(),
+                otel_exporter_otlp_endpoint: "http://localhost".into(),
+                otel_service_name: "test".into(),
+                rate_limit_per_second: 1,
+                rate_limit_burst_size: 1,
+                http_headers: None,
+                jwt_secret: "secret".into(),
+            }),
+            registry: Arc::new(prometheus::Registry::new()),
+        };
+
         Router::new()
             .route("/", get(test_handler))
-            .layer(axum::middleware::from_fn(auth_middleware)) // Use auth_middleware directly
+            .layer(axum::middleware::from_fn_with_state(app_state.clone(), auth_middleware))
+            .with_state(app_state)
     }
 
-    // The old wrapper auth_middleware_wrapper is no longer needed here as auth_middleware's signature is compatible.
-    // async fn auth_middleware_wrapper(
-    //     request: Request,
-    //     next: Next,
-    // ) -> Result<Response, StatusCode> {
-    //     // Headers are extracted inside auth_middleware now
-    //     auth_middleware(request, next).await
-    // }
 
 
     #[tokio::test]
@@ -144,18 +110,35 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 
     #[tokio::test]
     async fn test_auth_middleware_with_bearer_header() {
         let app = app_with_middleware();
 
+        let token = {
+            use jsonwebtoken::{encode, EncodingKey, Header};
+            use std::time::{SystemTime, UNIX_EPOCH};
+
+            let exp = SystemTime::now()
+                .duration_since(UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as usize
+                + 60;
+            let claims = Claims {
+                sub: "tester".into(),
+                exp,
+            };
+            encode(&Header::default(), &claims, &EncodingKey::from_secret(b"secret"))
+                .unwrap()
+        };
+
         let response = app
             .oneshot(
                 Request::builder()
                     .uri("/")
-                    .header(header::AUTHORIZATION, "Bearer sometoken123")
+                    .header(header::AUTHORIZATION, format!("Bearer {}", token))
                     .body(Body::empty())
                     .unwrap(),
             )
@@ -163,8 +146,6 @@ mod tests {
             .unwrap();
 
         assert_eq!(response.status(), StatusCode::OK);
-        // In a real scenario, you would assert that the token was processed
-        // or user information was added to the request.
     }
 
     #[tokio::test]
@@ -182,7 +163,6 @@ mod tests {
             .await
             .unwrap();
 
-        assert_eq!(response.status(), StatusCode::OK);
-        // Assert that it's handled gracefully, even if not "Bearer"
+        assert_eq!(response.status(), StatusCode::UNAUTHORIZED);
     }
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -370,6 +370,7 @@ async fn test_structured_error_response() {
             name: "X-Test-Header".to_string(),
             value: "TestValue".to_string(),
         }]),
+        jwt_secret: "testsecret".to_string(),
     });
     let registry = prometheus::Registry::new();
     let app_state = AppState {


### PR DESCRIPTION
## Summary
- add jwt_secret to Config and default config
- implement JWT auth middleware using `jsonwebtoken`
- wire the middleware with application state
- update tests for JWT behavior
- ensure newline at EOF for Cargo.toml

## Testing
- `cargo check -q` *(fails to download crates index)*
- `cargo test --quiet` *(fails to download crates index)*

------
https://chatgpt.com/codex/tasks/task_e_68576044df388325b3760833fe1a89f2